### PR TITLE
Simulate drop rates

### DIFF
--- a/src/combatsimulator/combatSimulator.js
+++ b/src/combatsimulator/combatSimulator.js
@@ -27,7 +27,6 @@ class CombatSimulator extends EventTarget {
 
         this.eventQueue = new EventQueue();
         this.simResult = new SimResult();
-        this.simResult.setDropRateMultipliers(player);
     }
 
     async simulate(simulationTimeLimit) {
@@ -53,6 +52,7 @@ class CombatSimulator extends EventTarget {
         }
 
         this.simResult.simulatedTime = this.simulationTime;
+        this.simResult.setDropRateMultipliers(this.players[0]);
 
         return this.simResult;
     }
@@ -463,10 +463,6 @@ class CombatSimulator extends EventTarget {
             // console.log("Added buff:", buff);
             let checkBuffExpirationEvent = new CheckBuffExpirationEvent(this.simulationTime + buff.duration, source);
             this.eventQueue.addEvent(checkBuffExpirationEvent);
-            
-            if (buff.typeHrid === "/buff_types/combat_drop_rate" || buff.typeHrid === "/buff_types/combat_rare_find") {
-                this.simResult.setDropRateMultipliers(source);
-            }
         }
 
         return true;

--- a/src/combatsimulator/combatSimulator.js
+++ b/src/combatsimulator/combatSimulator.js
@@ -462,6 +462,10 @@ class CombatSimulator extends EventTarget {
             // console.log("Added buff:", buff);
             let checkBuffExpirationEvent = new CheckBuffExpirationEvent(this.simulationTime + buff.duration, source);
             this.eventQueue.addEvent(checkBuffExpirationEvent);
+            
+            if (buff.typeHrid === "/buff_types/combat_drop_rate") {
+                this.simResult.setDropRateMultipliers(source);
+            }
         }
 
         return true;

--- a/src/combatsimulator/combatSimulator.js
+++ b/src/combatsimulator/combatSimulator.js
@@ -27,6 +27,7 @@ class CombatSimulator extends EventTarget {
 
         this.eventQueue = new EventQueue();
         this.simResult = new SimResult();
+        this.simResult.setDropRateMultipliers(player);
     }
 
     async simulate(simulationTimeLimit) {
@@ -463,7 +464,7 @@ class CombatSimulator extends EventTarget {
             let checkBuffExpirationEvent = new CheckBuffExpirationEvent(this.simulationTime + buff.duration, source);
             this.eventQueue.addEvent(checkBuffExpirationEvent);
             
-            if (buff.typeHrid === "/buff_types/combat_drop_rate") {
+            if (buff.typeHrid === "/buff_types/combat_drop_rate" || buff.typeHrid === "/buff_types/combat_rare_find") {
                 this.simResult.setDropRateMultipliers(source);
             }
         }

--- a/src/combatsimulator/combatUnit.js
+++ b/src/combatsimulator/combatUnit.js
@@ -211,10 +211,11 @@ class CombatUnit {
         this.combatDetails.combatStats.physicalReflectPower += this.getBuffBoost(
             "/buff_types/physical_reflect_power"
         ).flatBoost;
-        this.combatDetails.combatStats.combatDropRate += this.getBuffBoost("/buff_types/combat_drop_rate").flatBoost;
         this.combatDetails.combatStats.combatExperience += this.getBuffBoost("/buff_types/wisdom").flatBoost;
         this.combatDetails.combatStats.criticalRate += this.getBuffBoost("/buff_types/crit").flatBoost;
         this.combatDetails.combatStats.criticalDamage += this.getBuffBoost("/buff_types/crit").flatBoost;
+
+        this.combatDetails.combatStats.combatDropRate = (1 + this.combatDetails.combatStats.combatDropRate) * this.getBuffBoost("/buff_types/combat_drop_rate").ratioBoost - 1;
     }
 
     addBuff(buff, currentTime) {

--- a/src/combatsimulator/combatUnit.js
+++ b/src/combatsimulator/combatUnit.js
@@ -215,7 +215,7 @@ class CombatUnit {
         this.combatDetails.combatStats.criticalRate += this.getBuffBoost("/buff_types/crit").flatBoost;
         this.combatDetails.combatStats.criticalDamage += this.getBuffBoost("/buff_types/crit").flatBoost;
 
-        this.combatDetails.combatStats.combatDropRate = (1 + this.combatDetails.combatStats.combatDropRate) * this.getBuffBoost("/buff_types/combat_drop_rate").ratioBoost - 1;
+        this.combatDetails.combatStats.combatDropRate = (1 + this.combatDetails.combatStats.combatDropRate) * this.getBuffBoost("/buff_types/combat_drop_rate").ratioBoost;
     }
 
     addBuff(buff, currentTime) {

--- a/src/combatsimulator/combatUnit.js
+++ b/src/combatsimulator/combatUnit.js
@@ -215,7 +215,8 @@ class CombatUnit {
         this.combatDetails.combatStats.criticalRate += this.getBuffBoost("/buff_types/crit").flatBoost;
         this.combatDetails.combatStats.criticalDamage += this.getBuffBoost("/buff_types/crit").flatBoost;
 
-        this.combatDetails.combatStats.combatDropRate = (1 + this.combatDetails.combatStats.combatDropRate) * this.getBuffBoost("/buff_types/combat_drop_rate").ratioBoost;
+        this.combatDetails.combatStats.combatDropRate += (1 + this.combatDetails.combatStats.combatDropRate) * this.getBuffBoost("/buff_types/combat_drop_rate").ratioBoost;
+        this.combatDetails.combatStats.combatRareFind += (1 + this.combatDetails.combatStats.combatRareFind) * this.getBuffBoost("/buff_types/combat_rare_find").ratioBoost;
     }
 
     addBuff(buff, currentTime) {

--- a/src/combatsimulator/player.js
+++ b/src/combatsimulator/player.js
@@ -94,6 +94,7 @@ class Player extends CombatUnit {
             "MPRegen",
             "physicalReflectPower",
             "combatDropRate",
+            "combatRareFind",
             "combatDropQuantity",
             "combatExperience",
             "criticalRate",

--- a/src/combatsimulator/simResult.js
+++ b/src/combatsimulator/simResult.js
@@ -7,6 +7,7 @@ class SimResult {
         this.consumablesUsed = {};
         this.hitpointsGained = {};
         this.manapointsGained = {};
+        this.dropRateMultiplier = 1;
         this.playerRanOutOfMana = false;
     }
 
@@ -91,6 +92,10 @@ class SimResult {
         }
 
         this.manapointsGained[unit.hrid][source] += amount;
+    }
+
+    setDropRateMultipliers(unit) {
+        this.dropRateMultiplier = unit.combatDetails.combatStats.combatDropRate;
     }
 }
 

--- a/src/combatsimulator/simResult.js
+++ b/src/combatsimulator/simResult.js
@@ -95,7 +95,7 @@ class SimResult {
     }
 
     setDropRateMultipliers(unit) {
-        this.dropRateMultiplier = unit.combatDetails.combatStats.combatDropRate;
+        this.dropRateMultiplier = 1 + unit.combatDetails.combatStats.combatDropRate;
     }
 }
 

--- a/src/combatsimulator/simResult.js
+++ b/src/combatsimulator/simResult.js
@@ -8,6 +8,7 @@ class SimResult {
         this.hitpointsGained = {};
         this.manapointsGained = {};
         this.dropRateMultiplier = 1;
+        this.rareFindMultiplier = 1;
         this.playerRanOutOfMana = false;
     }
 
@@ -96,6 +97,7 @@ class SimResult {
 
     setDropRateMultipliers(unit) {
         this.dropRateMultiplier = 1 + unit.combatDetails.combatStats.combatDropRate;
+        this.rareFindMultiplier = 1 + unit.combatDetails.combatStats.combatRareFind;
     }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -735,7 +735,7 @@ function showKills(simResult) {
     let dropsResultDiv = document.getElementById("simulationResultDrops");
     let newChildren = [];
     let newDropChildren = [];
-    let dropRateMultiplier = player.combatDetails.combatStats.combatDropRate + 1;
+    let dropRateMultiplier = (player.combatDetails.combatStats.combatDropRate + 1) * simResult.dropRateMultiplier;
     let rareFindMultiplier = player.combatDetails.combatStats.combatRareFind + 1;
 
     let hoursSimulated = simResult.simulatedTime / ONE_HOUR;

--- a/src/main.js
+++ b/src/main.js
@@ -735,7 +735,7 @@ function showKills(simResult) {
     let dropsResultDiv = document.getElementById("simulationResultDrops");
     let newChildren = [];
     let newDropChildren = [];
-    let dropRateMultiplier = (player.combatDetails.combatStats.combatDropRate + 1) * simResult.dropRateMultiplier;
+    let dropRateMultiplier = simResult.dropRateMultiplier;
     let rareFindMultiplier = player.combatDetails.combatStats.combatRareFind + 1;
 
     let hoursSimulated = simResult.simulatedTime / ONE_HOUR;

--- a/src/main.js
+++ b/src/main.js
@@ -736,7 +736,7 @@ function showKills(simResult) {
     let newChildren = [];
     let newDropChildren = [];
     let dropRateMultiplier = simResult.dropRateMultiplier;
-    let rareFindMultiplier = player.combatDetails.combatStats.combatRareFind + 1;
+    let rareFindMultiplier = simResult.rareFindMultiplier;
 
     let hoursSimulated = simResult.simulatedTime / ONE_HOUR;
     let playerDeaths = simResult.deaths["player"] ?? 0;

--- a/src/main.js
+++ b/src/main.js
@@ -735,6 +735,8 @@ function showKills(simResult) {
     let dropsResultDiv = document.getElementById("simulationResultDrops");
     let newChildren = [];
     let newDropChildren = [];
+    let dropRateMultiplier = player.combatDetails.combatStats.combatDropRate + 1;
+    let rareFindMultiplier = player.combatDetails.combatStats.combatRareFind + 1;
 
     let hoursSimulated = simResult.simulatedTime / ONE_HOUR;
     let playerDeaths = simResult.deaths["player"] ?? 0;
@@ -759,20 +761,21 @@ function showKills(simResult) {
         const dropMap = new Map();
         const rareDropMap = new Map();
         for (const drop of combatMonsterDetailMap[monster].dropTable) {
-            dropMap.set(drop.itemHrid.slice(drop.itemHrid.lastIndexOf("/") + 1).replaceAll("_", " "), {"dropRate": drop.dropRate, "number": 0, "dropMin": drop.minCount, "dropMax": drop.maxCount});
+            dropMap.set(drop.itemHrid.slice(drop.itemHrid.lastIndexOf("/") + 1).replaceAll("_", " "), {"dropRate": drop.dropRate * dropRateMultiplier, "number": 0, "dropMin": drop.minCount, "dropMax": drop.maxCount});
         }
         for (const drop of combatMonsterDetailMap[monster].rareDropTable) {
-            rareDropMap.set(drop.itemHrid.slice(drop.itemHrid.lastIndexOf("/") + 1).replaceAll("_", " "), {"dropRate": drop.dropRate, "number": 0, "dropMin": drop.minCount, "dropMax": drop.maxCount});
+            rareDropMap.set(drop.itemHrid.slice(drop.itemHrid.lastIndexOf("/") + 1).replaceAll("_", " "), {"dropRate": drop.dropRate * rareFindMultiplier, "number": 0, "dropMin": drop.minCount, "dropMax": drop.maxCount});
         }
         for (let i = 0; i < simResult.deaths[monster]; i++) {
-            let chance = Math.random();
             for (let dropObject of dropMap.values()) {
+                let chance = Math.random();
                 if (chance <= dropObject.dropRate) {
                     let amount = Math.floor(Math.random() * (dropObject.dropMax - dropObject.dropMin + 1) + dropObject.dropMin)
                     dropObject.number = dropObject.number + amount;
                 }
             }
             for (let dropObject of rareDropMap.values()) {
+                let chance = Math.random();
                 if (chance <= dropObject.dropRate) {
                     let amount = Math.floor(Math.random() * (dropObject.dropMax - dropObject.dropMin + 1) + dropObject.dropMin)
                     dropObject.number = dropObject.number + amount;


### PR DESCRIPTION
This makes each drop table entry roll independently, and includes the drop rate/rare find boosts in the simulated loot!

To test: fight Jerry with ridiculous stats and gear. Try equipping/unequipping lucky coffee and rerunning the simulation, looking at the total drops of wheat. You should see roughly 15% more wheat. Then, try equipping/unequipping +20 rare find jewelry. You should see ~80% more treasure chests.